### PR TITLE
feat: implement rtl addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This packages comes with extra addons that further tweak the base Jest configura
 
 | Addon | Description |
 | :---: | --- |
-| [withWeb](addons/with-web/) | Adds setup and ignore patterns we use in [`next-with-moxy`](https://www.github.com/moxystudio/next-with-moxy) |
+| [withWeb](addons/with-web/) | Adds setup and ignore patterns we use in [`next-with-moxy`](https://www.github.com/moxystudio/next-with-moxy). |
 | [withRTL](addons/with-rtl/) | Adds setup for projects using [React Testing Library](https://github.com/testing-library/react-testing-library). |
 
 To use addons, use the `compose` function that comes with this package. **Keep in mind**, the first item should always be the default configuration, `baseConfig`! Here's an example of using `compose`:

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ This packages comes with extra addons that further tweak the base Jest configura
 | Addon | Description |
 | :---: | --- |
 | [withWeb](addons/with-web/) | Adds setup and ignore patterns we use in [`next-with-moxy`](https://www.github.com/moxystudio/next-with-moxy) |
+| [withRTL](addons/with-rtl/) | Adds setup for projects using [React Testing Library](https://github.com/testing-library/react-testing-library). |
 
 To use addons, use the `compose` function that comes with this package. **Keep in mind**, the first item should always be the default configuration, `baseConfig`! Here's an example of using `compose`:
 

--- a/addons/index.js
+++ b/addons/index.js
@@ -1,3 +1,4 @@
 'use strict';
 
 module.exports.withWeb = require('./with-web');
+module.exports.withRTL = require('./with-rtl');

--- a/addons/with-rtl/README.md
+++ b/addons/with-rtl/README.md
@@ -14,7 +14,7 @@ const { compose, baseConfig, withRTL } = require('@moxy/jest-config');
 module.exports = compose([baseConfig, withRTL]);
 ```
 
-### What's included in `withWeb`?
+### What's included in `withRTL`?
 
 This addon adds configurations to our base configuration to help develop projects using React Testing Library](https://github.com/testing-library/react-testing-library):
 - **Extended expect:** Using [`jest-dom`](https://github.com/testing-library/jest-dom) to make DOM assertions easier and clearer.

--- a/addons/with-rtl/README.md
+++ b/addons/with-rtl/README.md
@@ -1,0 +1,20 @@
+# withRTL
+
+An addon for [`jest-config`](https://www.github.com/moxystudio/jest-config) for projects developed with [React Testing Library](https://github.com/testing-library/react-testing-library).
+
+If you're already using [`withWeb`](../with-web/), you don't need to include this addon.
+
+## Usage
+
+To use addons, use the `compose` function that comes with this package. **Keep in mind**, the first item should always be the default configuration, `baseConfig`! Here's an example of using `compose` to include this addon:
+
+```js
+const { compose, baseConfig, withRTL } = require('@moxy/jest-config');
+
+module.exports = compose([baseConfig, withRTL]);
+```
+
+### What's included in `withWeb`?
+
+This addon adds configurations to our base configuration to help develop projects using React Testing Library](https://github.com/testing-library/react-testing-library):
+- **Extended expect:** Using [`jest-dom`](https://github.com/testing-library/jest-dom) to make DOM assertions easier and clearer.

--- a/addons/with-rtl/index.js
+++ b/addons/with-rtl/index.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = (config = {}) => {
+    const {
+        setupFilesAfterEnv = [],
+    } = config;
+
+    config.setupFilesAfterEnv = [
+        ...setupFilesAfterEnv,
+        '@testing-library/jest-dom/extend-expect',
+    ];
+
+    return config;
+};

--- a/addons/with-web/README.md
+++ b/addons/with-web/README.md
@@ -2,6 +2,8 @@
 
 An addon for [`jest-config`](https://www.github.com/moxystudio/jest-config) for projects developed with [`next-with-moxy`](https://www.github.com/moxystudio/next-with-moxy).
 
+This addon already includes the settings that come with the [withRTL](../with-rtl/) addon.
+
 ## Usage
 
 To use addons, use the `compose` function that comes with this package. **Keep in mind**, the first item should always be the default configuration, `baseConfig`! Here's an example of using `compose` to include this addon:

--- a/addons/with-web/README.md
+++ b/addons/with-web/README.md
@@ -14,7 +14,7 @@ module.exports = compose([baseConfig, withWeb]);
 
 ### What's included in `withWeb`?
 
-THis addon add configurations to our base configuration to help develop projects using [`next-with-moxy`](https://www.github.com/moxystudio/next-with-moxy):
+This addon adds configurations to our base configuration to help develop projects using [`next-with-moxy`](https://www.github.com/moxystudio/next-with-moxy):
 - **Transform:** Includes preprocessors for data-url file imports and inline file content imports. Note, we're using [`next-with-moxy`](https://www.github.com/moxystudio/next-with-moxy) naming conventions to know which files to process with each preprocessor.
 - **Coverage collection and ignore patterns:** Conforming to the folder and naming conventions of [`next-with-moxy`](https://www.github.com/moxystudio/next-with-moxy).
 - **Extended expect:** Using [`jest-dom`](https://github.com/testing-library/jest-dom) to make DOM assertions easier and clearer.

--- a/test/__snapshots__/with-rtl.test.js.snap
+++ b/test/__snapshots__/with-rtl.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should match snapshot 1`] = `
+Object {
+  "setupFilesAfterEnv": Array [
+    "@testing-library/jest-dom/extend-expect",
+  ],
+}
+`;

--- a/test/with-rtl.test.js
+++ b/test/with-rtl.test.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const configWeb = require('../addons/with-rtl');
+
+it('should match snapshot', () => {
+    expect(configWeb()).toMatchSnapshot();
+});


### PR DESCRIPTION
This PR implements and addon that only sets up `jest-dom` in case the developer is using RTL.
