### PR TITLE
fix: fix testMatch pattern to not accept jsx

### DIFF
--- a/lib/__snapshots__/base-config.test.js.snap
+++ b/lib/__snapshots__/base-config.test.js.snap
@@ -77,7 +77,7 @@ Object {
   "testFailureExitCode": 1,
   "testLocationInResults": false,
   "testMatch": Array [
-    "**/?(*.)test.[jt]s?(x)",
+    "**/?(*.)test.[jt]s",
   ],
   "testPathIgnorePatterns": Array [
     "/node_modules/",

--- a/lib/base-config.js
+++ b/lib/base-config.js
@@ -29,6 +29,6 @@ module.exports = () => ({
         require.resolve('jest-serializer-path'),
     ],
     testMatch: [
-        '**/?(*.)test.[jt]s?(x)',
+        '**/?(*.)test.[jt]s',
     ],
 });


### PR DESCRIPTION
This is to be inline with eslint-config, as we disallow the jsx extension.