### PR TITLE
Move Animated mock to React Native enhancer

### DIFF
--- a/lib/enhancers/enzyme/setup-react-native.js
+++ b/lib/enhancers/enzyme/setup-react-native.js
@@ -18,6 +18,3 @@ const wrapConsoleMethod = (fn) => (message, ...rest) => {
 console.error = wrapConsoleMethod(console.error);
 console.warn = wrapConsoleMethod(console.warn);
 
-// Fixes warning for "Animated: useNativeDriver is not supported because the native animated module is missing..."
-// See: https://github.com/ptomasroos/react-native-scrollable-tab-view/issues/642#issuecomment-593166721
-jest.mock('react-native/Libraries/Animated/src/NativeAnimatedHelper');

--- a/lib/enhancers/react-native/__snapshots__/index.test.js.snap
+++ b/lib/enhancers/react-native/__snapshots__/index.test.js.snap
@@ -13,7 +13,8 @@ Object {
   },
   "setupFiles": Array [
     "foo",
-    "./jest/setup.js",
+    "react-native/jest/setup.js",
+    "./setup.js",
   ],
   "testEnvironment": "jsdom",
   "transform": Object {

--- a/lib/enhancers/react-native/index.js
+++ b/lib/enhancers/react-native/index.js
@@ -32,6 +32,7 @@ module.exports = (options) => {
         setupFiles: [
             ...config.setupFiles,
             ...reactNativePreset.setupFiles,
+            './setup.js',
         ],
     });
 };

--- a/lib/enhancers/react-native/index.test.js
+++ b/lib/enhancers/react-native/index.test.js
@@ -15,7 +15,7 @@ jest.mock('react-native/jest-preset', () => ({
     transformIgnorePatterns: [
         'node_modules/(?!(jest-)?react-native|@react-native-community)',
     ],
-    setupFiles: ['./jest/setup.js'],
+    setupFiles: ['react-native/jest/setup.js'],
     testEnvironment: 'node',
 }), {
     virtual: true,

--- a/lib/enhancers/react-native/setup.js
+++ b/lib/enhancers/react-native/setup.js
@@ -1,0 +1,7 @@
+/* eslint-env jest */
+
+'use strict';
+
+// Fixes warning for "Animated: useNativeDriver is not supported because the native animated module is missing..."
+// See: https://github.com/ptomasroos/react-native-scrollable-tab-view/issues/642#issuecomment-593166721
+jest.mock('react-native/Libraries/Animated/src/NativeAnimatedHelper');


### PR DESCRIPTION
The warning:

> Animated: `useNativeDriver` is not supported because the native animated module is missing. Falling back to JS-based animation. To resolve this, add `RCTAnimation` module to this app, or remove `useNativeDriver`. More info: https://github.com/facebook/react-native/issues/11094#issuecomment-263240420

is not specific to the use of Enzyme, as it is also displayed when we use React Native Testing library. Therefore, we should move the mock of React Native's Animated library from the Enzyme enhancer to React Native's.