### PR TITLE
Use require.resolve to include React Native setup file

### DIFF
--- a/lib/__snapshots__/base-config.test.js.snap
+++ b/lib/__snapshots__/base-config.test.js.snap
@@ -4,6 +4,7 @@ exports[`should match snapshot 1`] = `
 Object {
   "automock": false,
   "bail": 0,
+  "browser": false,
   "cache": true,
   "cacheDirectory": "<TEMP_DIR>/jest_1",
   "changedFilesWithAncestor": false,
@@ -33,6 +34,7 @@ Object {
   "globals": Object {},
   "haste": Object {
     "computeSha1": false,
+    "providesModuleNodeModules": Array [],
     "throwOnModuleCollision": false,
   },
   "maxConcurrency": 5,

--- a/lib/enhancers/enzyme/README.md
+++ b/lib/enhancers/enzyme/README.md
@@ -42,20 +42,20 @@ An enhancer for React Native projects tested with [Enzyme](https://github.com/ai
 - **Wrapper snapshotting**: Ability to snapshot Enzyme wrappers by using [enzyme-to-json](https://www.npmjs.com/package/enzyme-to-json).
 - **Ignore certain warnings and errors**: [Ignore warnings and errors](https://github.com/enzymejs/enzyme/issues/831) produced by React due to the fact that we are using JSDOM in React Native, as [prescribed](https://enzymejs.github.io/enzyme/docs/guides/react-native.html) by Enzyme.
 - **Extended matchers**: Make assertions easier and clearer by using `jest-enzyme` [matchers](https://github.com/FormidableLabs/enzyme-matchers/tree/master/packages/jest-enzyme#assertions). Only React Native-compatible matchers are installed:
-    - `toBeDisabled()`,
-    - `toBeEmptyRender()`,
-    - `toExist()`,
-    - `toContainMatchingElement()`,
-    - `toContainMatchingElements()`,
-    - `toContainExactlyOneMatchingElement()`,
-    - `toContainReact()`,
-    - `toHaveDisplayName()`,
-    - `toHaveProp()`,
-    - `toHaveRef()`,
-    - `toHaveState()`,
-    - `toIncludeText()`,
-    - `toMatchElement()`,
-    - `toMatchSelector()`,
+    - `toBeDisabled()`
+    - `toBeEmptyRender()`
+    - `toExist()`
+    - `toContainMatchingElement()`
+    - `toContainMatchingElements()`
+    - `toContainExactlyOneMatchingElement()`
+    - `toContainReact()`
+    - `toHaveDisplayName()`
+    - `toHaveProp()`
+    - `toHaveRef()`
+    - `toHaveState()`
+    - `toIncludeText()`
+    - `toMatchElement()`
+    - `toMatchSelector()`
 
 ## Usage
 

--- a/lib/enhancers/react-native/__snapshots__/index.test.js.snap
+++ b/lib/enhancers/react-native/__snapshots__/index.test.js.snap
@@ -14,7 +14,7 @@ Object {
   "setupFiles": Array [
     "foo",
     "react-native/jest/setup.js",
-    "./setup.js",
+    "<PROJECT_ROOT>/lib/enhancers/react-native/setup.js",
   ],
   "testEnvironment": "jsdom",
   "transform": Object {

--- a/lib/enhancers/react-native/index.js
+++ b/lib/enhancers/react-native/index.js
@@ -32,7 +32,7 @@ module.exports = (options) => {
         setupFiles: [
             ...config.setupFiles,
             ...reactNativePreset.setupFiles,
-            './setup.js',
+            require.resolve('./setup.js'),
         ],
     });
 };


### PR DESCRIPTION
## Summary

Without `require.resolve` Jest was unable to resolve the actual location of the setup file and exiting with an error.

## Unrelated changes

- Removed unnecessary commas from bullet points in README
- Fixed `baseConfig` snapshot