### PR TITLE
Ignore known enzyme/jsdom warnings emitted in React Native

### DIFF
--- a/lib/__snapshots__/base-config.test.js.snap
+++ b/lib/__snapshots__/base-config.test.js.snap
@@ -4,7 +4,6 @@ exports[`should match snapshot 1`] = `
 Object {
   "automock": false,
   "bail": 0,
-  "browser": false,
   "cache": true,
   "cacheDirectory": "<TEMP_DIR>/jest_1",
   "changedFilesWithAncestor": false,
@@ -34,7 +33,6 @@ Object {
   "globals": Object {},
   "haste": Object {
     "computeSha1": false,
-    "providesModuleNodeModules": Array [],
     "throwOnModuleCollision": false,
   },
   "maxConcurrency": 5,

--- a/lib/enhancers/enzyme/README.md
+++ b/lib/enhancers/enzyme/README.md
@@ -22,7 +22,7 @@ const { compose, baseConfig, withEnzymeWeb } = require('@moxy/jest-config');
 
 module.exports = compose(
     baseConfig(),
-    withEnzyme('enzyme-adapter-react-16'),
+    withEnzymeWeb('enzyme-adapter-react-16'),
 );
 ```
 
@@ -62,15 +62,24 @@ An enhancer for React Native projects tested with [Enzyme](https://github.com/ai
 To use this enhancer, use the `compose` function that comes with this package. **Keep in mind**, the first item should always be the base configuration!
 
 ```js
-const { compose, baseConfig, withEnzymeWeb } = require('@moxy/jest-config');
+const { compose, baseConfig, withEnzymeReactNative } = require('@moxy/jest-config');
 
 module.exports = compose(
     baseConfig(),
-    withEnzyme('enzyme-adapter-react-16'),
+    withEnzymeReactNative('enzyme-adapter-react-16', options),
 );
 ```
 
 ⚠️ Note that you **must install** the Enzyme adapter yourself. In the example above, you would have to install `enzyme-adapter-react-16`:
+
+### options
+
+#### ignoreExtraMessagePatterns
+
+Type: `Array`
+Default: `[]`
+
+An array of regexp pattern strings that are matched against errors or warnings emitted by React and filtered out. There are several messages which already ignored by default. This option allows to exclude additional messages if necessary.
 
 ```sh
 $ npm install --save-dev enzyme-adapter-react-16

--- a/lib/enhancers/enzyme/__snapshots__/index.test.js.snap
+++ b/lib/enhancers/enzyme/__snapshots__/index.test.js.snap
@@ -1,9 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`withEnzymeReactNative it should accept extra ignore message patterns and match snapshot 1`] = `
+Object {
+  "globals": Object {
+    "__MOXY_JEST_CONFIG_ENZYME_ADAPTER__": "enzyme-adapter-react-16",
+    "__MOXY_JEST_CONFIG_ENZYME_REACT_NATIVE_IGNORE_EXTRA_MESSAGE_PATTERNS__": Array [
+      "foo",
+      "bar",
+    ],
+    "foo": "bar",
+  },
+  "setupFilesAfterEnv": Array [
+    "foo",
+    "<PROJECT_ROOT>/lib/enhancers/enzyme/setup.js",
+    "<PROJECT_ROOT>/lib/enhancers/enzyme/setup-react-native.js",
+  ],
+  "testEnvironment": "jsdom",
+}
+`;
+
 exports[`withEnzymeReactNative should match snapshot 1`] = `
 Object {
   "globals": Object {
     "__MOXY_JEST_CONFIG_ENZYME_ADAPTER__": "enzyme-adapter-react-16",
+    "__MOXY_JEST_CONFIG_ENZYME_REACT_NATIVE_IGNORE_EXTRA_MESSAGE_PATTERNS__": Array [],
     "foo": "bar",
   },
   "setupFilesAfterEnv": Array [

--- a/lib/enhancers/enzyme/index.js
+++ b/lib/enhancers/enzyme/index.js
@@ -38,7 +38,12 @@ module.exports.withEnzymeWeb = (adapter) => {
     };
 };
 
-module.exports.withEnzymeReactNative = (adapter) => {
+module.exports.withEnzymeReactNative = (adapter, options) => {
+    options = {
+        ignoreExtraMessagePatterns: [],
+        ...options,
+    };
+
     const applyEnzyme = withEnzyme(adapter);
 
     return (config) => {
@@ -46,6 +51,10 @@ module.exports.withEnzymeReactNative = (adapter) => {
 
         return {
             ...config,
+            globals: {
+                ...config.globals,
+                __MOXY_JEST_CONFIG_ENZYME_REACT_NATIVE_IGNORE_EXTRA_MESSAGE_PATTERNS__: options.ignoreExtraMessagePatterns,
+            },
             setupFilesAfterEnv: [
                 ...config.setupFilesAfterEnv,
                 require.resolve('./setup-react-native'),

--- a/lib/enhancers/enzyme/index.test.js
+++ b/lib/enhancers/enzyme/index.test.js
@@ -34,6 +34,12 @@ describe('withEnzymeReactNative', () => {
         expect(withEnzymeReactNative('enzyme-adapter-react-16')(buildConfig())).toMatchSnapshot();
     });
 
+    it('it should accept extra ignore message patterns and match snapshot', () => {
+        expect(
+            withEnzymeReactNative('enzyme-adapter-react-16', { ignoreExtraMessagePatterns: ['foo', 'bar'] })(buildConfig()),
+        ).toMatchSnapshot();
+    });
+
     it('should throw if no adapter is passed', () => {
         expect(() => withEnzymeReactNative()).toThrow(/please provide an enzyme adapter/i);
     });

--- a/lib/enhancers/enzyme/setup-react-native.js
+++ b/lib/enhancers/enzyme/setup-react-native.js
@@ -1,17 +1,24 @@
+/* global __MOXY_JEST_CONFIG_ENZYME_REACT_NATIVE_IGNORE_EXTRA_MESSAGE_PATTERNS__:true */
 /* eslint-env jest */
 
 'use strict';
 
-const getCallerFile = require('get-caller-file');
 const extendEnzymeMatchers = require('./matchers');
 
 const wrapConsoleMethod = (fn) => (message, ...rest) => {
     // Ignores logs coming from `react-dom` and similar, see: https://github.com/enzymejs/enzyme/issues/831#issuecomment-542851439
     // This is needed as we need JSDOM for Enzyme, while `react-native` doesn't really use it
-    const blockPatternCallerFile = /(react-dom.development).js/i;
-    const blockPatternMessage = /(module is not correctly linked)/i;
+    const ignoreMessagePatterns = [
+        '<.* /> is using incorrect casing. Use PascalCase for React components, or lowercase for HTML elements.',
+        'The tag <.*> is unrecognized in this browser. If you meant to render a React component, start its name with an uppercase letter.',
+        'React does not recognize the `.*` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `.*` instead. If you accidentally passed it from a parent component, remove it from the DOM element.',
+        'Received `.*` for a non-boolean attribute `.*`.',
+        'Unknown event handler property `.*`. It will be ignored.',
+        ...__MOXY_JEST_CONFIG_ENZYME_REACT_NATIVE_IGNORE_EXTRA_MESSAGE_PATTERNS__,
+    ].join('|');
+    const regexp = new RegExp(ignoreMessagePatterns, 'i');
 
-    if (!blockPatternMessage.test(message) && !blockPatternCallerFile.test(getCallerFile())) {
+    if (!regexp.test(message)) {
         return fn(message, ...rest);
     }
 };

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "enzyme": "^3.11.0",
     "enzyme-matchers": "^7.1.2",
     "enzyme-to-json": "^3.4.4",
-    "get-caller-file": "^2.0.5",
     "identity-obj-proxy": "^3.0.0",
     "jest-config": "^26.0.0",
     "jest-serializer-path": "^0.1.15",


### PR DESCRIPTION
## Summary

I've found out that attempting to filter out error/warning messages emitted by Enzyme/JSDOM by inspecting the stack trace does not work really well. There are major issues with this approach:
- It's too heavy handed. Messages such as [`act(...)` warnings](https://kentcdodds.com/blog/fix-the-not-wrapped-in-act-warning) and prop type warnings are filtered out too which is bad.
- `getCallerFile`, by default, returns the third call site of the stack. In one of our apps, there is an additional call site, `YellowBox.js`, which pushes `react-dom.development.js` further down in the stack and thus letting the logged message pass through. Therefore, inspecting the stack turns out to be a fragile strategy. 

I know that having an array of regexp pattern strings is not the ideal approach, but I don't think there is an ideal approach for this problem besides get rid of Enzyme altogether and start using [React Native Testing Library](https://callstack.github.io/react-native-testing-library/). For the time being, and to best support React Native apps that still make use of Enzyme for testing, this is probably the best we can do.   

## Unrelated changes

- Fixed `baseConfig` snapshot (again). I don't know what went wrong with the snapshot in https://github.com/moxystudio/jest-config/pull/21. 🤷 