### PR TITLE
Add Native Testing Library setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ There are several **enhancer** packages, which are intended to be used in conjun
   module.exports = compose(
     baseConfig(),
     withWeb(),
-    withEnzymeWeb('enzyme-adapter-react-16'),
+    withEnzymeWeb('enzyme-adapter-react-16'), // ⚠️ Always after .withWeb
   );
   ```
 
@@ -72,7 +72,7 @@ There are several **enhancer** packages, which are intended to be used in conjun
   module.exports = compose(
     baseConfig(),
     withWeb(),
-    withRTL(),
+    withRTL(), // ⚠️ Always after .withWeb
   );
   ```
 
@@ -84,12 +84,12 @@ There are several **enhancer** packages, which are intended to be used in conjun
   ```js
   const { compose, baseConfig } = require('@moxy/jest-config-base');
   const withReactNative = require('@moxy/jest-config-react-native');
-  const { withEnzymeNative } = require('@moxy/jest-config-enzyme');
+  const { withEnzymeReactNative } = require('@moxy/jest-config-enzyme');
     
   module.exports = compose(
     baseConfig(),
     withReactNative(),
-    withEnzymeNative('enzyme-adapter-react-16'),
+    withEnzymeReactNative('enzyme-adapter-react-16'), // ⚠️ Always after .withReactNative
   );
   ```
 
@@ -106,7 +106,7 @@ There are several **enhancer** packages, which are intended to be used in conjun
   module.exports = compose(
     baseConfig('node'),
     withReactNative(),
-    withNTL(),
+    withNTL(), // ⚠️ Always after .withReactNative
   );
   ```
     

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,13 @@
 'use strict';
 
-module.exports = require('./packages/jest-config-base').baseConfig();
+const { compose, baseConfig } = require('./packages/jest-config-base');
+
+module.exports = compose(
+    baseConfig('node'),
+    (config) => ({
+        ...config,
+        // Inspired by: https://github.com/facebook/jest/issues/9543#issuecomment-616358056
+        // A custom module resolver is needed so we can mock require.resolve with virtual modules
+        resolver: require.resolve('./jest/resolve-modules'),
+    }),
+);

--- a/jest/resolve-modules.js
+++ b/jest/resolve-modules.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const VIRTUAL_MODULES = [
+    '@testing-library/react-native/cleanup-after-each',
+];
+
+module.exports = (path, options) => {
+    if (VIRTUAL_MODULES.includes(path)) {
+        return path;
+    }
+
+    return options.defaultResolver(path, options);
+};

--- a/packages/jest-config-enzyme/README.md
+++ b/packages/jest-config-enzyme/README.md
@@ -50,6 +50,8 @@ module.exports = compose(
 
 ⚠️ Note that you **must install** the Enzyme adapter yourself. In the example above, you would have to install `enzyme-adapter-react-16`:
 
+⚠️ Make sure `withEnzymeWeb` is composed only after `withWeb` from `@moxy/jest-config-web`.
+
 ```sh
 $ npm install --save-dev enzyme-adapter-react-16
 ```
@@ -94,6 +96,8 @@ module.exports = compose(
 ```
 
 ⚠️ Note that you **must install** the Enzyme adapter yourself. In the example above, you would have to install `enzyme-adapter-react-16`:
+
+⚠️ Make sure `withEnzymeReactNative` is composed only after `withReactNative` from `@moxy/jest-config-react-native`.
 
 ### options
 

--- a/packages/jest-config-testing-library/README.md
+++ b/packages/jest-config-testing-library/README.md
@@ -48,6 +48,8 @@ module.exports = compose(
 );
 ```
 
+⚠️ Make sure `withRTL` is composed only after `withWeb` from `@moxy/jest-config-web`.
+
 # withNTL
 
 An enhancer for React Native apps tested with Native Testing Library.
@@ -69,3 +71,5 @@ module.exports = compose(
     withNTL(),
 );
 ```
+
+⚠️ Make sure `withNTL` is composed only after `withReactNative` from `@moxy/jest-config-react-native`.

--- a/packages/jest-config-testing-library/lib/__mocks__/@testing-library/react-native/cleanup-after-each.js
+++ b/packages/jest-config-testing-library/lib/__mocks__/@testing-library/react-native/cleanup-after-each.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = () => {};

--- a/packages/jest-config-testing-library/lib/__mocks__/@testing-library/react-native/jest-preset.js
+++ b/packages/jest-config-testing-library/lib/__mocks__/@testing-library/react-native/jest-preset.js
@@ -1,0 +1,33 @@
+'use strict';
+
+// Copied and adapted from: https://github.com/facebook/react-native/blob/master/jest-preset.js
+const mockReactNativePreset = {
+    haste: {
+        defaultPlatform: 'ios',
+        platforms: ['android', 'ios', 'native'],
+    },
+    transform: {
+        '^.+\\.(js|ts|tsx)$': 'babel-jest',
+        '^.+\\.(bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp)$': './jest/assetFileTransformer.js',
+    },
+    transformIgnorePatterns: [
+        'node_modules/(?!(jest-)?react-native|@react-native-community)',
+    ],
+    setupFiles: ['react-native/jest/setup.js'],
+    testEnvironment: 'node',
+};
+
+// Copied and adapted from: https://github.com/testing-library/native-testing-library/blob/master/jest-preset.js
+module.exports = {
+    transformIgnorePatterns: [
+        ...mockReactNativePreset.transformIgnorePatterns,
+        'node_modules/(?!(react-native.*|@?react-navigation.*)/)',
+    ],
+    snapshotSerializers: ['./dist/preset/serializer.js'],
+    setupFiles: [
+        // Intentionally duplicated to assert duplicates are removed
+        ...mockReactNativePreset.setupFiles,
+        ...mockReactNativePreset.setupFiles,
+        './dist/preset/setup.js',
+    ],
+};

--- a/packages/jest-config-testing-library/lib/__snapshots__/index.test.js.snap
+++ b/packages/jest-config-testing-library/lib/__snapshots__/index.test.js.snap
@@ -2,9 +2,19 @@
 
 exports[`withNTL should match snapshot 1`] = `
 Object {
+  "setupFiles": Array [
+    "bar",
+    "react-native/jest/setup.js",
+    "./dist/preset/setup.js",
+  ],
   "setupFilesAfterEnv": Array [
     "foo",
     "<PROJECT_ROOT>/node_modules/@testing-library/jest-native/extend-expect.js",
+    "@testing-library/react-native/cleanup-after-each",
+  ],
+  "snapshotSerializers": Array [
+    "baz",
+    "./dist/preset/serializer.js",
   ],
   "testEnvironment": "node",
 }

--- a/packages/jest-config-testing-library/lib/index.js
+++ b/packages/jest-config-testing-library/lib/index.js
@@ -17,11 +17,26 @@ const withRTL = () => (config) => {
 const withNTL = () => (config) => {
     assert(config.testEnvironment === 'node', new TypeError('Expected testEnvironment to be set to "node".'));
 
+    const nativeTestingLibraryPreset = require('@testing-library/react-native/jest-preset');
+    const removeDuplicates = (array) => [...new Set(array)];
+
     return ({
         ...config,
         setupFilesAfterEnv: [
             ...config.setupFilesAfterEnv,
             require.resolve('@testing-library/jest-native/extend-expect'),
+            require.resolve('@testing-library/react-native/cleanup-after-each'),
+        ],
+        // Native Testing Library includes React Native preset in its own setup.
+        // Since .withReactNative from jest-config-react-native already takes care of that,
+        // we have to remove the duplicated path to the preset module from the array.
+        setupFiles: removeDuplicates([
+            ...config.setupFiles,
+            ...nativeTestingLibraryPreset.setupFiles,
+        ]),
+        snapshotSerializers: [
+            ...config.snapshotSerializers,
+            ...nativeTestingLibraryPreset.snapshotSerializers,
         ],
     });
 };

--- a/packages/jest-config-testing-library/lib/index.test.js
+++ b/packages/jest-config-testing-library/lib/index.test.js
@@ -26,6 +26,8 @@ describe('withNTL', () => {
     const buildConfig = () => ({
         testEnvironment: 'node',
         setupFilesAfterEnv: ['foo'],
+        setupFiles: ['bar'],
+        snapshotSerializers: ['baz'],
     });
 
     it('should match snapshot', () => {

--- a/packages/jest-config-testing-library/package.json
+++ b/packages/jest-config-testing-library/package.json
@@ -4,6 +4,7 @@
   "version": "5.0.0",
   "files": [
     "lib",
+    "!**/__mocks__",
     "!**/*.test.js",
     "!**/__snapshots__"
   ],


### PR DESCRIPTION
## Summary

- Added Native Testing Library's Jest preset
- Added `cleanup-after-each` to `setupFilesAfterEnv`. Unlike in React Testing Library, [clean up is not called automatically](https://www.native-testing-library.com/docs/setup#cleanup).
- Added custom module resolver to Jest's config to be able to mock `require.resolve` for virtual modules.