### PR TITLE
Add project URLs to root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,11 @@
 {
   "name": "root",
   "private": true,
+  "homepage": "https://github.com/moxystudio/jest-config",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:moxystudio/jest-config.git"
+  },
   "scripts": {
     "lint": "eslint --ignore-path .gitignore .",
     "test": "jest",


### PR DESCRIPTION
This is necessary otherwise URLs which allow to compare the differences between two tags will be broken in the root `CHANGELOG.md` after running `lerna publish` with `conventionalcommits` preset.

Current output for version heading:

```
## [6.0.0](///compare/v5.4.0...v6.0.0) (2020-06-18)
```

Expected output:

```
### [6.0.1](https://github.com/moxystudio/jest-config/compare/v6.0.0...v6.0.1) (2020-06-18)
```