### PR TITLE
Fix README config samples order and code indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,51 +45,38 @@ There are several **enhancer** packages, which are intended to be used in conjun
 </details>
 
 <details>
-  <summary>Web project with Enzyme</summary>
-
-  ```js
-  const { compose, baseConfig } = require('@moxy/jest-config-base');
-  const withWeb = require('@moxy/jest-config-web');
-  const { withEnzymeWeb } = require('@moxy/jest-config-enzyme');
-    
-  module.exports = compose(
-    baseConfig(),
-    withWeb(),
-    withEnzymeWeb('enzyme-adapter-react-16'), // ⚠️ Always after .withWeb
-  );
-  ```
-
-</details>
-
-<details>
   <summary>Web project with RTL</summary>
 
   ```js
+  'use strict';
+
   const { compose, baseConfig } = require('@moxy/jest-config-base');
   const withWeb = require('@moxy/jest-config-web');
   const { withRTL } = require('@moxy/jest-config-testing-library');
     
   module.exports = compose(
-    baseConfig(),
-    withWeb(),
-    withRTL(), // ⚠️ Always after .withWeb
+      baseConfig(),
+      withWeb(),
+      withRTL(), // ⚠️ Always after .withWeb
   );
   ```
 
 </details>
 
 <details>
-  <summary>React Native project with Enzyme</summary>
+  <summary>Web project with Enzyme</summary>
 
   ```js
+  'use strict';
+
   const { compose, baseConfig } = require('@moxy/jest-config-base');
-  const withReactNative = require('@moxy/jest-config-react-native');
-  const { withEnzymeReactNative } = require('@moxy/jest-config-enzyme');
+  const withWeb = require('@moxy/jest-config-web');
+  const { withEnzymeWeb } = require('@moxy/jest-config-enzyme');
     
   module.exports = compose(
-    baseConfig(),
-    withReactNative(),
-    withEnzymeReactNative('enzyme-adapter-react-16'), // ⚠️ Always after .withReactNative
+      baseConfig(),
+      withWeb(),
+      withEnzymeWeb('enzyme-adapter-react-16'), // ⚠️ Always after .withWeb
   );
   ```
 
@@ -99,17 +86,38 @@ There are several **enhancer** packages, which are intended to be used in conjun
   <summary>React Native project with NTL</summary>
 
   ```js
+  'use strict';
+
   const { compose, baseConfig } = require('@moxy/jest-config-base');
   const withReactNative = require('@moxy/jest-config-react-native');
   const { withNTL } = require('@moxy/jest-config-testing-library');
     
   module.exports = compose(
-    baseConfig('node'),
-    withReactNative(),
-    withNTL(), // ⚠️ Always after .withReactNative
+      baseConfig('node'),
+      withReactNative(),
+      withNTL(), // ⚠️ Always after .withReactNative
   );
   ```
     
+</details>
+
+<details>
+  <summary>React Native project with Enzyme</summary>
+
+  ```js
+  'use strict';
+  
+  const { compose, baseConfig } = require('@moxy/jest-config-base');
+  const withReactNative = require('@moxy/jest-config-react-native');
+  const { withEnzymeReactNative } = require('@moxy/jest-config-enzyme');
+    
+  module.exports = compose(
+      baseConfig(),
+      withReactNative(),
+      withEnzymeReactNative('enzyme-adapter-react-16'), // ⚠️ Always after .withReactNative
+  );
+  ```
+
 </details>
 
 ## Older versions

--- a/packages/jest-config-base/README.md
+++ b/packages/jest-config-base/README.md
@@ -35,6 +35,8 @@ $ npm install --save-dev jest @moxy/eslint-config-base
 Create `jest.config.js` at the root of your project:
 
 ```js
+'use strict';
+
 const { baseConfig } = require('@moxy/jest-config-base');
 
 module.exports = baseConfig();
@@ -56,6 +58,8 @@ Alternatively, you may pass a path to a custom environment. In fact, we offer th
   Special Node environment class for Jest which runs all scripts in the same context. This effectively disables the sandbox isolation to circumvent issues with Jest's [sandboxing](https://github.com/facebook/jest/issues/2549), which causes subtle bugs in specific situations, such as in code that relies in `instanceof` checks.
 
   ```js
+  'use strict';
+
   const { baseConfig } = require('@moxy/jest-config');
 
   module.exports = baseConfig('@moxy/jest-config/environments/node-single-context');
@@ -69,6 +73,8 @@ Alternatively, you may pass a path to a custom environment. In fact, we offer th
 To use enhancers, use the `compose` function that comes with this package. **Keep in mind**, the first item should always be the base configuration! Here's an example of using `compose`:
 
 ```js
+'use strict';
+
 const { compose, baseConfig } = require('@moxy/jest-config-base');
 const withMyEnhancer = require('<your-own-enhancer>');
 
@@ -81,6 +87,8 @@ module.exports = compose(
 Enhancers are functions which accept a single argument, i.e., Jest's config object, and return the enhanced config. You may also use `compose` to add your own inline enhancer:
 
 ```js
+'use strict';
+
 const { compose, baseConfig } = require('@moxy/jest-config');
 
 module.exports = compose(
@@ -101,6 +109,8 @@ module.exports = compose(
 If you want to modify the base config without using `compose`, you may change the config imperatively like so:
 
 ```js
+'use strict';
+
 const { baseConfig } = require('@moxy/jest-config');
 
 const config = baseConfig();

--- a/packages/jest-config-enzyme/README.md
+++ b/packages/jest-config-enzyme/README.md
@@ -39,6 +39,8 @@ An enhancer for web projects tested with Enzyme.
 To use this enhancer, use the `compose` function that comes with `@moxy/jest-config-base`. **Keep in mind**, the first item should always be the base configuration!
 
 ```js
+'use strict';
+
 const { compose, baseConfig } = require('@moxy/jest-config-base');
 const { withEnzymeWeb } = require('@moxy/jest-config-enzyme');
 
@@ -86,6 +88,8 @@ An enhancer for React Native projects tested with [Enzyme](https://github.com/ai
 To use this enhancer, use the `compose` function that comes with `@moxy/jest-config-base`. **Keep in mind**, the first item should always be the base configuration!
 
 ```js
+'use strict';
+
 const { compose, baseConfig } = require('@moxy/jest-config-base');
 const { withEnzymeReactNative } = require('@moxy/jest-config-enzyme');
 

--- a/packages/jest-config-react-native/README.md
+++ b/packages/jest-config-react-native/README.md
@@ -34,6 +34,8 @@ This package should be used in conjunction with `@moxy/jest-config-base`.
 To use this enhancer, use the `compose` function that comes with this package. **Keep in mind**, the first item should always be the base configuration!
 
 ```js
+'use strict';
+
 const { compose, baseConfig } = require('@moxy/jest-config-base');
 const withReactNative = require('@moxy/jest-config-react-native');
 
@@ -50,6 +52,8 @@ The enhancer accepts an options object as the first argument with the following 
 To showcase the usefulness of `transformModules`, let's pretend that you use [React Navigation](https://reactnavigation.org/) in your project. You would need to compile its packages to make them work in Jest, so you would add them to `transformModules` like so:
 
 ```js
+'use strict';
+
 const { compose, baseConfig } = require('@moxy/jest-config');
 const withReactNative = require('@moxy/jest-config-react-native');
 

--- a/packages/jest-config-testing-library/README.md
+++ b/packages/jest-config-testing-library/README.md
@@ -39,6 +39,8 @@ An enhancer for web projects tested with React Testing Library.
 To use this enhancer, use the `compose` function that comes with this package. **Keep in mind**, the first item should always be the base configuration!
 
 ```js
+'use strict';
+
 const { compose, baseConfig } = require('@moxy/jest-config-base');
 const { withRTL } = require('@moxy/jest-config-testing-library');
 
@@ -63,6 +65,8 @@ An enhancer for React Native apps tested with Native Testing Library.
 To use this enhancer, use the `compose` function that comes with this package. **Keep in mind**, the first item should always be the base configuration!
 
 ```js
+'use strict';
+
 const { compose, baseConfig } = require('@moxy/jest-config-base');
 const { withNTL } = require('@moxy/jest-config-testing-library');
 


### PR DESCRIPTION
## Changes

- Configs for RTL/NTL now appear before the ones for Enzyme.
- Source code is now indented with 4 spaces.
- Added `'use strict'` to the top of every code block.