### PR TITLE
feat(base config): add gltf file transform

### DIFF
--- a/packages/jest-config-base/lib/__snapshots__/base-config.test.js.snap
+++ b/packages/jest-config-base/lib/__snapshots__/base-config.test.js.snap
@@ -87,7 +87,7 @@ Object {
   "transform": Object {
     "/.(eot|ttf|woff|woff2|otf)$": "<PROJECT_ROOT>/packages/jest-config-base/lib/transforms/file.js",
     "/.(mp3|flac|wav|aac|ogg|oga|mp4|m4a|webm|ogv)$": "<PROJECT_ROOT>/packages/jest-config-base/lib/transforms/file.js",
-    "/.(obj|mtl|fnt|glb)$": "<PROJECT_ROOT>/packages/jest-config-base/lib/transforms/file.js",
+    "/.(obj|mtl|fnt|gltf|glb)$": "<PROJECT_ROOT>/packages/jest-config-base/lib/transforms/file.js",
     "/.(png|jpg|jpeg|gif|webp|svg|ico|bmp)$": "<PROJECT_ROOT>/packages/jest-config-base/lib/transforms/file.js",
     "/.[jt]s$": "<PROJECT_ROOT>/node_modules/babel-jest/build/index.js",
     "/.data-url/.[^/.+?]$": "<PROJECT_ROOT>/packages/jest-config-base/lib/transforms/data-url.js",

--- a/packages/jest-config-base/lib/base-config.js
+++ b/packages/jest-config-base/lib/base-config.js
@@ -16,7 +16,7 @@ module.exports = (testEnvironment = 'jsdom') => ({
         '\\.(png|jpg|jpeg|gif|webp|svg|ico|bmp)$': require.resolve('./transforms/file'),
         '\\.(eot|ttf|woff|woff2|otf)$': require.resolve('./transforms/file'),
         '\\.(mp3|flac|wav|aac|ogg|oga|mp4|m4a|webm|ogv)$': require.resolve('./transforms/file'),
-        '\\.(obj|mtl|fnt|glb)$': require.resolve('./transforms/file'),
+        '\\.(obj|mtl|fnt|gltf|glb)$': require.resolve('./transforms/file'),
         '\\.data-url\\.[^\\.+?]$': require.resolve('./transforms/data-url'),
         '\\.inline\\.[^\\.+?]$': require.resolve('./transforms/inline'),
     },


### PR DESCRIPTION
As a companion to this [PR](https://github.com/moxystudio/next-common-files/pull/14) on [@moxy/next-common-files](https://github.com/moxystudio/next-common-files), which added support for `.gltf` files, this PR adds support for transforming `.gltf` files in the Jest configuration.